### PR TITLE
Fixes Internal Server Error when editing a worker.

### DIFF
--- a/htdocs/admin/workers.php
+++ b/htdocs/admin/workers.php
@@ -204,9 +204,9 @@ class AdminWorkersController extends AdminController
         return new AdminWorkerNewEditView(array('worker' => new WorkerModel($row)));
     }
 
-    public function editPostView()
+    public function editPostView(WorkerModel $worker)
     {
-        return $this->newPostView();
+        return $this->newPostView($worker);
     }
 }
 


### PR DESCRIPTION
Missing parameters on function and passing the variable along to another function caused Internal Server Error. Fixes issue #17.
